### PR TITLE
Please use cultureinfo when parsing

### DIFF
--- a/Allfiles/Labfiles/Lab02/PatrolCarDevice/PatrolCar/Program.cs
+++ b/Allfiles/Labfiles/Lab02/PatrolCarDevice/PatrolCar/Program.cs
@@ -32,6 +32,9 @@ namespace PatrolCar
                 Trace.WriteLine("One or more parameters missing in appsettings (app.config)");
                 return;
             }
+            
+            // Change Culture settings to en-US
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
 
             var driver = new PatrolCarsDriver(connectionString, iotHubUri, int.Parse(numCars), double.Parse(latNorth), 
                 double.Parse(latSouth), double.Parse(longEast), double.Parse(longWest), 


### PR DESCRIPTION
Do not assume that everyone runs the lab in an english lab enviroment.
Countries that use comma's instead of periods end up with very large longitudes and latitudes values and PowerBI will not show anything.

![image](https://user-images.githubusercontent.com/10166617/46760182-a3044f80-ccd1-11e8-93c5-1268e8502e9d.png)
